### PR TITLE
fix: Use of undefined variables

### DIFF
--- a/404.liquid
+++ b/404.liquid
@@ -1,6 +1,7 @@
 extends: default.liquid
 title: Food not found
 path: 404.html
+route: about
 ---
 
 <img class="corner" src="/img/404.png" />

--- a/blog/2017-0001-flattening-xml.md
+++ b/blog/2017-0001-flattening-xml.md
@@ -3,6 +3,7 @@ title: Code generation scripts in PL/SQL
 date: 10 May 2017 16:49:09 +0100
 path: 2017/flattening-xml
 tags: codegen, plsql, oracle, xml
+route: blog
 ---
 ## Flattening XML paths
 

--- a/blog/2017-0002-mba-setup.md
+++ b/blog/2017-0002-mba-setup.md
@@ -3,6 +3,7 @@ title: MacBook Air Setup
 date: 4 Jun 2017 16:49:09 +0100
 path: 2017/mba-setup
 tags: mac, homebrew, vscode, vim, setup
+route: blog
 ---
 Here's my current setup for my MacBook Air Setup. I use a range of tools like 
 homebrew, Visual Studio Code and vim.

--- a/blog/2017-0003-github-pages-cobalt.md
+++ b/blog/2017-0003-github-pages-cobalt.md
@@ -3,6 +3,7 @@ title: Using Cobalt with GitHub pages
 date: 11 Jun 2017 18:29:09 +0100
 path: 2017/cobalt-github
 tags: cobalt,github
+route: blog
 ---
 
 It turns out using [Cobalt](https://github.com/cobalt-org/cobalt.rs) and your 

--- a/blog/2017-0004-gh-pages-custom-domain.md
+++ b/blog/2017-0004-gh-pages-custom-domain.md
@@ -3,6 +3,7 @@ title: Using a custom domain with GitHub Pages
 date: 13 Jun 2017 08:02:54 +0100
 path: 2017/gh-pages-custom-domain
 tags: cobalt,github,dns
+route: blog
 ---
 
 It took far too long to work out how to do this on the GitHub help pages...

--- a/blog/2017-0005-add-reading-time.md
+++ b/blog/2017-0005-add-reading-time.md
@@ -3,6 +3,7 @@ title: Add reading time in Cobalt
 date: 15 Jun 2017 09:05:37 +0100
 path: 2017/add-reading-time
 tags: cobalt,github,liquid
+route: blog
 ---
 
 I wanted to add an approximate reading time to each of my blog posts, like 

--- a/blog/2017-0006-useful-commit-messages.md
+++ b/blog/2017-0006-useful-commit-messages.md
@@ -3,6 +3,7 @@ title: Useful commit messages
 date: 16 Jun 2017 09:09:18 +0100
 path: 2017/useful-commit-messages
 tags: git
+route: blog
 ---
 Keeping a copy of this excellent bit of advice until I've committed (no pun) it
 to memory.

--- a/blog/2017-0007-adding-search-to-your-cobalt-site-part-one.md
+++ b/blog/2017-0007-adding-search-to-your-cobalt-site-part-one.md
@@ -3,6 +3,7 @@ title: Adding search to your cobalt site - Part One
 date: 20 Jun 2017 08:06:11 +0100
 path: 2017/adding-search-to-your-cobalt-site-part-one
 tags: cobalt,github,search,lunr,liquid
+route: blog
 ---
 This will be a two part post, where I detail the steps it took to enable
 search on my [Cobalt](https://github.com/cobalt-org/cobalt.rs) site.

--- a/blog/2017-0008-adding-search-to-your-cobalt-site-part-two.md
+++ b/blog/2017-0008-adding-search-to-your-cobalt-site-part-two.md
@@ -3,6 +3,7 @@ title: Adding search to your cobalt site - Part Two
 date: 20 Jun 2017 08:35:51 +0100
 path: 2017/adding-search-to-your-cobalt-site-part-two
 tags: cobalt,github,search,lunr,liquid
+route: blog
 ---
 This will be a two part post, where I detail the steps it took to enable
 search on my [Cobalt](https://github.com/cobalt-org/cobalt.rs) site.

--- a/blog/2017-0009-useful-git-commands.md
+++ b/blog/2017-0009-useful-git-commands.md
@@ -3,6 +3,7 @@ title: Useful git commmands
 date: 22 Jun 2017 18:51:43 +0100
 path: 2017/useful-git-commands
 tags: git
+route: blog
 ---
 
 ## Commit logs

--- a/blog/2017-0010-prebuilt-lunr-indexes.md
+++ b/blog/2017-0010-prebuilt-lunr-indexes.md
@@ -3,6 +3,7 @@ title: Using pre-built lunr indexes
 date: 22 Jun 2017 19:21:00 +0100
 path: 2017/prebuilt-lunr-indexes
 tags: cobalt,search,lunr
+route: blog
 ---
 I've implemented pre-built indexes vs. on demand i.e. generating them when the 
 search page is being loaded. I'm not entirely happy with the solution yet for 

--- a/blog/2017-0011-hidden-files.md
+++ b/blog/2017-0011-hidden-files.md
@@ -3,6 +3,7 @@ title: See hidden files in Finder
 date: 1 Jul 2017 14:21:50 +0100
 path: 2017/hidden-files
 tags: mac, finder
+route: blog
 ---
 If you search for how to do this, you get a lot of nonsense involving messing with defaults write and horrific applescript bodges.
 

--- a/blog/2017-0012-collapsible-html-sections.md
+++ b/blog/2017-0012-collapsible-html-sections.md
@@ -3,6 +3,7 @@ title: Collapsible Sections in HTML
 date: 1 Jul 2017 15:55:44 +0100
 path: 2017/collapsible-sections
 tags: html, github
+route: blog
 ---
 ## But first a demo...
 

--- a/blog/2017-0013-defensive-coding-sql.md
+++ b/blog/2017-0013-defensive-coding-sql.md
@@ -1,4 +1,5 @@
 extends: post.liquid
+route: blog
 title: Defensive coding in SQL
 date: 1 Jul 2017 16:33:04 +0100
 path: 2017/defensive-coding-sql

--- a/blog/2017-0013-defensive-coding-sql.md
+++ b/blog/2017-0013-defensive-coding-sql.md
@@ -1,8 +1,9 @@
 extends: post.liquid
-route: blog
 title: Defensive coding in SQL
 date: 1 Jul 2017 16:33:04 +0100
 path: 2017/defensive-coding-sql
+tags: ""
+route: blog
 ---
 Always wrap ON clauses in parens to avoid predicates being deleted
 accidentally. The following code will scream if you delete the AND clause.

--- a/blog/2017-0014-plsql-script-cursors.md
+++ b/blog/2017-0014-plsql-script-cursors.md
@@ -3,6 +3,7 @@ title: PL/SQL script to query a refcursor
 date: 1 Jul 2017 16:49:01 +0100
 path: 2017/plsql-script-cursors
 tags: cursors, oracle, plsql
+route: blog
 ---
 This will probably work in pipelined functions or packages too. Note the use of
 the bind variable to link the PL/SQL script variables to the out refcursor.

--- a/blog/2017-0015-bind-vs-substitution.md
+++ b/blog/2017-0015-bind-vs-substitution.md
@@ -3,6 +3,7 @@ title: Bind vs Substitution variables
 date: 1 Jul 2017 18:02:45 +0100
 path: 2017/bind-vs-substitution
 tags: oracle, plsql, variables, bind, substitution
+route: blog
 ---
 I always have difficulty remember the difference between these type of 
 variables. Although now, that I've started doing a lot of ORDS related work,

--- a/blog/2017-0016-when-xml-attacks.md
+++ b/blog/2017-0016-when-xml-attacks.md
@@ -3,6 +3,7 @@ title: When XML attacks!
 date: 1 Jul 2017 18:11:10 +0100
 path: 2017/when-xml-attacks
 tags: oracle, xmltype, xml, extractvalue
+route: blog
 ---
 At some point in your xml wrangling career you will hit an node whose data is
 too big for Oracle's `EXTRACTVALUE` (I think the upper limit is 4000

--- a/blog/2017-0017-dirty-dynamic-sql.md
+++ b/blog/2017-0017-dirty-dynamic-sql.md
@@ -3,6 +3,7 @@ title: Dirty Dynamic SQL
 date: 1 Jul 2017 18:19:52 +0100
 path: 2017/dirty-dynamic-sql
 tags: dynamic, sql, danger, oneliners, codegen
+route: blog
 ---
 Not all dynamic sql is strictly for immediate execution, nor is it dirty (I
 needed aninteresting title). I learnt this tricks from my friend at work, he's

--- a/blog/2017-0018-bitmasks-sql.md
+++ b/blog/2017-0018-bitmasks-sql.md
@@ -3,6 +3,7 @@ title: Bitmasks in SQL
 date: 1 Jul 2017 18:27:29 +0100
 path: 2017/bitmasks-sql
 tags: oracle, sql, bitmasks
+route: blog
 ---
 
 bitmasks are really handy way to express predicates without becoming overly

--- a/blog/2017-0019-sql-developer-format-hints.md
+++ b/blog/2017-0019-sql-developer-format-hints.md
@@ -3,6 +3,7 @@ title: SQL Developer's new format hints
 date: 1 Jul 2017 18:40:24 +0100
 path: 2017/sql-developer-format-hints
 tags: sqldeveloper,csv,format
+route: blog
 ---
 One of my favourite cool features in SQL Developer is the ability to turn a sql
 query output into an entirely different format. It doesn't even require 

--- a/blog/2017-0020-flashback.md
+++ b/blog/2017-0020-flashback.md
@@ -3,6 +3,7 @@ title: Flashback, what did this data look like previously?
 date: 1 Jul 2017 18:44:06 +0100
 path: 2017/flashback
 tags: oracle, flashback, lsd
+route: blog
 ---
 I'm only scratching the surface of what you can do with flashbacks in Oracle. 
 Our DBAs are absolute ninjas when it comes to using this witchcraft from Oracle.

--- a/blog/2017-0021-adding-an-archive.md
+++ b/blog/2017-0021-adding-an-archive.md
@@ -3,6 +3,7 @@ title: Adding an archive page to your Cobalt blog
 date: 4 Jul 2017 16:13:01 +0100
 path: 2017/adding-an-archive
 tags: cobalt,liquid
+route: blog
 ---
 
 To avoid slowing down the index page, there's a point where you need to limit

--- a/blog/2017-0022-youtube-dl.md
+++ b/blog/2017-0022-youtube-dl.md
@@ -3,6 +3,7 @@ title: youtube-dl gems
 date: 4 Jul 2017 16:42:14 +0100
 path: 2017/youtube-dl
 tags: youtube-dl
+route: blog
 ---
 A handy collection of youtube-dl incantations, remember it's not just for 
 youtube-dl! There's plenty more, but these are the one use I use on a daily 

--- a/blog/2017-0023-python.md
+++ b/blog/2017-0023-python.md
@@ -3,6 +3,7 @@ title: python tips
 date: 4 Jul 2017 16:54:51 +0100
 path: 2017/python
 tags: python, homebrew, raspbian
+route: blog
 ---
 A random collection of Python tips, I also write Python code in MacOS and
 raspbian so you'll see tips for those platforms.

--- a/blog/2017-0024-exercism-python.md
+++ b/blog/2017-0024-exercism-python.md
@@ -3,6 +3,7 @@ title: Setting up exercism python track with Visual Studio Code
 date: 4 Jul 2017 17:08:41 +0100
 path: 2017/exercism-python
 tags: python, exercism, pylint, pytest, pep8, vscode
+route: blog
 ---
 Here's a fairly good setup for getting the python track of exercism working
 with virtual env and Visual Studio Code.

--- a/blog/2017-0025-cobalt-tags.md
+++ b/blog/2017-0025-cobalt-tags.md
@@ -3,6 +3,7 @@ title: Add support for tags to Cobalt
 date: 9 Jul 2017 10:07:03 +0100
 path: 2017/cobalt-tags
 tags: cobalt, tags, taxonomies, categories
+route: blog
 ---
 A while back I started adding a new front matter attribute to all my posts
 called `tags`. I initially did this to improve my site search indexing (you can

--- a/blog/2017-0026-ords.md
+++ b/blog/2017-0026-ords.md
@@ -3,6 +3,7 @@ title: ORDS tips
 date: 13 Jul 2017 15:36:58 +0100
 path: 2017/ords
 tags: ords, xml, mime_types, oracle
+route: blog
 ---
 
 ## XML over ORDS

--- a/blog/2017-0027-variable-dispenser.md
+++ b/blog/2017-0027-variable-dispenser.md
@@ -3,6 +3,7 @@ title: SSIS Variable Dispenser Template
 date: 17 Jul 2017 16:00:00 +0100
 path: 2017/variable-dispenser
 tags: ssis, bids, template
+route: blog
 ---
 
 I don't write enough SSIS script blob tasks to commit this to memory. This is the safest way to access variables without inadvertantly locking them after a crash.

--- a/blog/2017-0028-cargo-cult-visual-studio.md
+++ b/blog/2017-0028-cargo-cult-visual-studio.md
@@ -3,6 +3,7 @@ title: Cargo cult - the problem with copying existing code
 date: 19 Jul 2017 11:52:00 +0100
 path: 2017/cargo-cult-visual-studio
 tags: cargocult,visualstudio,msbuild
+route: blog
 ---
 A quick note to myself on how to identify build errors. This is also a timely 
 reminder that you should create code from scratch once in a while, rather than 

--- a/blog/2017-0029-london-rust-14.md
+++ b/blog/2017-0029-london-rust-14.md
@@ -3,6 +3,7 @@ title: London Rust User Group Meetup No. 14
 date: 19 Jul 2017 17:56:21 +0100
 path: 2017/london-rust-14
 tags: rust,meetup,usergroup
+route: blog
 ---
 # Interwebs
 

--- a/blog/2017-0030-vscode-rls.md
+++ b/blog/2017-0030-vscode-rls.md
@@ -3,6 +3,7 @@ title: Rust Language Server and Visual Studio Code
 date: 24 Jul 2017 08:08:41 +0100
 path: 2017/vscode-rls
 tags: rls,rust,vscode,languageserverprotocol
+route: blog
 ---
 
 Click [here](#tips) to skip the history lesson and go straight to the tips.

--- a/blog/2017-0031-rust-vscode.md
+++ b/blog/2017-0031-rust-vscode.md
@@ -3,6 +3,7 @@ title: Using Rust with Visual Studio Code
 date: 8 Aug 2017 07:39:42 +0100
 path: 2017/rust-vscode
 tags: rust,vscode,tips
+route: blog
 ---
 
 ## Which extension?

--- a/blog/2017-0032-message-queue-miscellany.md
+++ b/blog/2017-0032-message-queue-miscellany.md
@@ -3,6 +3,7 @@ title: Message Queue Miscellany
 date: 12 Aug 2017 14:13:12 +0100
 path: 2017/message-queue-miscellany
 tags: mq,messagequeue
+route: blog
 ---
 This is a bit of a hodge podge of message queue notes. Very IBM centric at the moment.
 

--- a/blog/2017-0033-london-rust-15.md
+++ b/blog/2017-0033-london-rust-15.md
@@ -3,6 +3,7 @@ title: London Rust User Group Meetup No. 15
 date: 16 Aug 2017 17:43:45 +0100
 path: 2017/london-rust-15
 tags: rust,meetup,usergroup
+route: blog
 ---
 # Interwebs
 

--- a/blog/2017-0034-regular-expressions.md
+++ b/blog/2017-0034-regular-expressions.md
@@ -3,6 +3,7 @@ title: Regular Expressions Miscellany
 date: 17 Aug 2017 08:42:25 +0100
 path: 2017/message-queue-miscellany
 tags: regularexpression,regex,oracle,notepad++
+route: blog
 ---
 
 ## Oracle related regular expressions

--- a/blog/2017-0035-troubleshooting-rls.md
+++ b/blog/2017-0035-troubleshooting-rls.md
@@ -3,6 +3,7 @@ title: Troubleshooting the Rust Language Server
 date: 18 Aug 2017 08:36:53 +0100
 path: 2017/troubleshooting-rls
 tags: rls,vscode,help
+route: blog
 ---
 
 To understand how to troubleshoot the Rust Language Server (RLS), it helps to know what RLS is and how the components interact.

--- a/blog/2017-0036-learning-rust-meta.md
+++ b/blog/2017-0036-learning-rust-meta.md
@@ -3,6 +3,7 @@ title: A developer on-boarding guide for Rust
 date: 31 Aug 2017 18:49:38 +0100
 path: 2017/learning-rust-meta
 tags: learning,rust
+route: blog
 ---
 
 Background: We needed a meta reference for our study group [event](https://www.meetup.com/Rust-London-User-Group/events/242378000/)!

--- a/blog/2017-0037-csharp-dotnet.md
+++ b/blog/2017-0037-csharp-dotnet.md
@@ -3,6 +3,7 @@ title: C Sharp and .NET tips
 date: 1 Sep 2017 07:33:15 +0100
 path: 2017/csharp-dotnet
 tags: c#,csharp,dotnet,.net,dotnetcore
+route: blog
 ---
 
 ## NUnit TestCases with instances of a type

--- a/blog/2017-0038-oracle-tips.md
+++ b/blog/2017-0038-oracle-tips.md
@@ -3,6 +3,7 @@ title: Oracle tips
 date: 28 Sep 2017 17:12:37 +0100
 path: 2017/oracle-tips
 tags: oracle,plsql,tips
+route: blog
 ---
 
 ## Hiding user input

--- a/blog/2017-0039-alexandria-plsql-utility-library.md
+++ b/blog/2017-0039-alexandria-plsql-utility-library.md
@@ -3,6 +3,7 @@ title: Alexandria PL/SQL Utility Library
 date: 11 Oct 2017 07:39:34 +0100
 path: 2017/alexandria-plsql-utility-library
 tags: oracle,plsql,ooxml,microsoft
+route: blog
 ---
 
 Imagine if BatMan was an Oracle DBA, his utility belt would be the [Alexandria PL/SQL Utility Library](https://github.com/mortenbra/alexandria-plsql-utils).

--- a/blog/2017-0040-nanogenmo-2017.md
+++ b/blog/2017-0040-nanogenmo-2017.md
@@ -3,6 +3,7 @@ title: National Novel Generation Month 2016 Reflection
 date: 12 Oct 2017 08:51:46 +0100
 path: 2017/nanogenmo-2016-reflection
 tags: procgen,nanogenmo,rust,bash
+route: blog
 ---
 
 [National Novel Generation Month](https://nanogenmo.github.io/) aka NaNoGenMo is a month long contest to write code to generate a novel of 50k+ words.

--- a/blog/2017-0041-remote-speaking-tips.md
+++ b/blog/2017-0041-remote-speaking-tips.md
@@ -4,6 +4,7 @@ title: Remote speaking tips
 date: 20 Oct 2017 20:05:52 +0100
 path: 2017/remote-speaking-tips
 tags: talks,publicspeaking,hangout,remote,livecoding,demo
+route: blog
 ---
 
 On Monday I did my first remote talk (for the [Rust

--- a/blog/2017-0042-mozfest-2017-rust.md
+++ b/blog/2017-0042-mozfest-2017-rust.md
@@ -3,6 +3,7 @@ title: MozFest 2017 Rust Resources
 date: 28 Oct 2017 12:36:38 +0100
 path: 2017/mozfest-2017-rust
 tags: rust,rustlang,mozfest,mozilla
+route: blog
 ---
 
 Here's the websites I've been touting at [MozFest](https://mozillafestival.org):

--- a/blog/2017-0043-london-perl-workshop-2017.md
+++ b/blog/2017-0043-london-perl-workshop-2017.md
@@ -3,6 +3,7 @@ title: London Perl Workshop 2017
 date: 28 Nov 2017 07:33:26 +0000
 path: 2017/london-perl-workshop
 tags: perl,lpw,rust
+route: blog
 ---
 
 Almost a month a go, around the same time as [Mozilla

--- a/blog/2017-0044-porting-python-turtle-examples-to-turtle-rs.md
+++ b/blog/2017-0044-porting-python-turtle-examples-to-turtle-rs.md
@@ -3,6 +3,7 @@ title: Porting python turtle examples to turtle.rs
 date: 15 Dec 2017 08:11:04 +0000
 path: 2017/porting-python-turtle-examples-to-turtle-rs
 tags: turtle,rust,python
+route: blog
 ---
 I've been tinkering around with the [Rust version](http://turtle.rs/) of [Turtle graphics](https://en.wikipedia.org/wiki/Turtle_graphics). Turtle graphics, was a key feature of the programming language [Logo](https://en.wikipedia.org/wiki/Logo_(programming_language)), and has frequently been ported to other programming languages as a visual way to teach programming.
 

--- a/license.md
+++ b/license.md
@@ -2,6 +2,7 @@ extends: default.liquid
 
 title: booyaa.github.io - License
 path:  license/
+route: about
 ---
 
 # License Information

--- a/search.liquid
+++ b/search.liquid
@@ -3,6 +3,7 @@ extends: default.liquid
 title: search
 path:  search/
 comment: search page for site 
+route: about
 ---
 <h4>type something to search for in the box below</h4>
 <p>

--- a/tags/cobalt.liquid
+++ b/tags/cobalt.liquid
@@ -3,6 +3,7 @@ extends: default.liquid
 title: booyaa's boggy bloggy
 path: tags/cobalt/
 comment: collection of cobalt related posts
+route: blog
 ---
 {% assign filter_tag = "cobalt" %}
 


### PR DESCRIPTION
For now, cobalt is becoming stricter on the user of undefined variables to help catch problems when migrating sites through https://github.com/cobalt-org/cobalt.rs/pull/346.

With this PR, your site correctly builds against 346 after running `cobalt migrate`.  Hopefully my guesses for how to change your site are close enough :).

I will follow up with a PR that migrates your site once 346 is dev complete.  Feel free to start playing with it and providing feedback (particularly around https://github.com/cobalt-org/cobalt.rs/issues/323).

I'd have included change to your travis file to lock down the version of cobalt used but travis is currently disabled for your site.